### PR TITLE
Fix bug in onPlayedTileInteraction lambda function

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest && codecov"
   },
   "dependencies": {
-    "@types/aws-lambda": "^8.10.59",
+    "@types/aws-lambda": "^8.10.60",
     "@types/node": "^14.0.27",
     "uuid": "^8.3.0"
   },
@@ -28,9 +28,9 @@
     "@types/jest": "^26.0.9",
     "@types/lambda-tester": "^3.6.0",
     "@types/uuid": "^8.0.1",
-    "@typescript-eslint/eslint-plugin": "^3.8.0",
-    "@typescript-eslint/parser": "^3.8.0",
-    "aws-sdk": "^2.729.0",
+    "@typescript-eslint/eslint-plugin": "^3.9.0",
+    "@typescript-eslint/parser": "^3.9.0",
+    "aws-sdk": "^2.730.0",
     "aws-sdk-mock": "^5.1.0",
     "eslint": "7.6.0",
     "eslint-config-airbnb-base": "14.2.0",
@@ -38,7 +38,7 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jest": "^23.20.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "jest": "^26.2.2",
+    "jest": "^26.3.0",
     "jest-dynalite": "^3.0.0",
     "jest-extended": "^0.11.5",
     "lambda-tester": "^4.0.1",

--- a/src/functions/functionsHelper.ts
+++ b/src/functions/functionsHelper.ts
@@ -12,6 +12,7 @@ import { getConnectionIdsFromUsers } from '../utils/broadcastHelper';
 import { deleteGameState } from '../dynamodb/gameStateDBService';
 import { sendUpdateResult } from '../types/gameUpdate';
 import { removeGameIdFromUser } from '../dynamodb/userDBService';
+import { DEFAULT_MAX_USERS_IN_GAME } from '../utils/constants';
 
 /**
  * Helper function to send updates to other users in the game when a user leaves the game.
@@ -75,4 +76,15 @@ export const sendUpdates = async (
   await broadcastInGameUpdate(ws, connectionId, updatedGame.users);
 
   return updateResult;
+};
+
+/**
+ * Find the next user to the one who played the tile.
+ * @param connectionId Current round user's connection Id
+ * @param connectionIds All connection Ids in a game (in fixed order in the db)
+ */
+export const findNextUser = (connectionId: string, connectionIds: string[]): string => {
+  const playedTileUserIndex = connectionIds.findIndex((cid) => cid === connectionId);
+  const canMakeConsecutiveIndex = playedTileUserIndex + 1 < DEFAULT_MAX_USERS_IN_GAME - 1 ? playedTileUserIndex + 1 : 0;
+  return connectionIds[canMakeConsecutiveIndex];
 };

--- a/src/functions/game/onPlayedTileInteraction.ts
+++ b/src/functions/game/onPlayedTileInteraction.ts
@@ -23,14 +23,20 @@ import { getConnectionIdsFromUsers } from '../../utils/broadcastHelper';
 import { getUsersInGame } from '../../dynamodb/gameDBService';
 import { User } from '../../models/User';
 import { broadcastInteractionSuccess } from '../../websocket/broadcast/gameStateBroadcast';
+import { findNextUser } from '../functionsHelper';
 
 /**
  * Compare played tile interaction and decide whose can make meld base on meld priority.
  * Send message to all user in the game about who can take the played tile.
  * @param {string} gameId Game Id
+ * @param {string} playedTileUserConnectionId Connection Id of user who played the tile
  * @param {WebSocketClient} ws WebSocketClient
  */
-export const compareTileInteractionAndSendUpdate = async (gameId: string, ws: WebSocketClient): Promise<void> => {
+export const compareTileInteractionAndSendUpdate = async (
+  gameId: string,
+  playedTileUserConnectionId: string,
+  ws: WebSocketClient,
+): Promise<void> => {
   const users = (await getUsersInGame(gameId)) as User[];
   const connectionIds = getConnectionIdsFromUsers(users);
 
@@ -54,47 +60,57 @@ export const compareTileInteractionAndSendUpdate = async (gameId: string, ws: We
     return;
   }
 
-  let messageSent = false;
-  let connectionId: string;
-  let numOfConsecutive = 0;
-  interactions.forEach((i): unknown => {
-    const { connectionId: cid, playedTiles: tile, meldType: meld } = i;
-
-    const wsPayload: InteractionSuccessPayload = {
-      connectionId: cid,
-      meldType: meld,
-      playedTiles: tile,
-      skipInteraction: false,
-    };
+  // Loop through interactions and determine which meld takes priority
+  // Precedence:
+  // 1. Triplet or Quad (once found, ignore other interaction objects)
+  // 2. Consecutive (only the next user to whom played the tile can make consecutive)
+  let tripletOrQuadPayload = {} as InteractionSuccessPayload;
+  let consecutivePayload = {} as InteractionSuccessPayload;
+  let canMakeTripletOrQuad = false;
+  // Not using forEach because breaking out of the forEach loop does not work
+  for (let i = 0; i < interactions.length; i += 1) {
+    const interaction: PlayedTile = interactions[i];
+    const { connectionId: cid, playedTiles: tile, meldType: meld } = interaction;
 
     /**
      * Making Triplet or Quad (Triplet and Quad takes precedence over Consecutive)
      */
-    if (!messageSent && (meld === MeldEnum.TRIPLET || meld === MeldEnum.QUAD)) {
-      messageSent = true;
-      return broadcastInteractionSuccess(ws, wsPayload, connectionIds);
+    if (meld === MeldEnum.TRIPLET || meld === MeldEnum.QUAD) {
+      canMakeTripletOrQuad = true;
+      tripletOrQuadPayload = {
+        connectionId: cid,
+        meldType: meld,
+        playedTiles: tile,
+        skipInteraction: false,
+      };
+      break; // once Triplet or Quad is found, break out of the for loop
     }
 
     /**
      * Making Consecutive
+     * Only one user (the next user to the user who played the tile) can make consecutive
      */
-    // Only one user (the next user to the user who played the tile) can make consecutive
-    if (meld === MeldEnum.CONSECUTIVE) {
-      numOfConsecutive += 1;
-      connectionId = cid;
-    }
+    if (!canMakeTripletOrQuad) {
+      // Found out who is the next user
+      const canMakeConsecutiveConnectionId = findNextUser(playedTileUserConnectionId, connectionIds);
 
-    // If no one make a Triplet or Quad, then a user can make consecutive if there is any
-    if (!messageSent && meld === MeldEnum.CONSECUTIVE && numOfConsecutive === 1) {
-      const newWsPayload = {
-        ...wsPayload,
-        connectionId,
-      };
-      return broadcastInteractionSuccess(ws, newWsPayload, connectionIds);
+      if (cid === canMakeConsecutiveConnectionId && meld === MeldEnum.CONSECUTIVE) {
+        consecutivePayload = {
+          connectionId: cid,
+          meldType: meld,
+          playedTiles: tile,
+          skipInteraction: false,
+        };
+      }
     }
+  }
 
-    return wsPayload;
-  });
+  const finalWsPayload: InteractionSuccessPayload = tripletOrQuadPayload || consecutivePayload;
+  console.log('Triplet Or Quad payload:', tripletOrQuadPayload);
+  console.log('Consecutive payload:', consecutivePayload);
+  console.log('Final INTERACTION_SUCCESS payload:', finalWsPayload);
+
+  await broadcastInteractionSuccess(ws, finalWsPayload, connectionIds);
 };
 
 /**
@@ -109,13 +125,14 @@ export const handler: Handler = async (event: WebSocketAPIGatewayEvent): Promise
   const body: LambdaEventBody = JSON.parse(event.body);
   const { payload }: { payload: LambdaEventBodyPayloadOptions } = body;
   const gameId = payload.gameId as string;
+  const playedTileUserConnectionId = payload.connectionId as string;
   const playedTiles = payload.playedTiles as string[];
   const meldType = payload.meldType as string;
   const skipInteraction = payload.skipInteraction as boolean;
 
   console.log('Incrementing interaction count and decide which meld type takes priority');
   const ws = new WebSocketClient(event.requestContext);
-  const playedTileResponse = { playedTiles, meldType, skipInteraction };
+  const playedTileResponse = { playedTiles, meldType, skipInteraction, connectionId: playedTileUserConnectionId };
   const playedTileInteractionResponse = createPlayedTileInteractionResponse(playedTileResponse);
   try {
     // Get current interaction count
@@ -141,7 +158,7 @@ export const handler: Handler = async (event: WebSocketAPIGatewayEvent): Promise
     let interactionEnded = false;
     if (newInteractionCount === 3) {
       interactionEnded = true;
-      await compareTileInteractionAndSendUpdate(gameId, ws);
+      await compareTileInteractionAndSendUpdate(gameId, playedTileUserConnectionId, ws);
     }
 
     // Reset interactionCount to be 0 and playedTile list to empty

--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -26,6 +26,7 @@ export interface LambdaEventBodyPayloadOptions {
   playedTiles?: string[];
   meldType?: string;
   skipInteraction?: boolean;
+  connectionId?: string;
 }
 
 export interface UserUpdatePayload {
@@ -87,6 +88,7 @@ export interface PlayTilePayload {
 }
 
 export interface PlayedTileInteractionPayload {
+  connectionId: string;
   playedTiles: string[];
   meldType: string;
   skipInteraction: boolean;

--- a/src/websocket/createWSResponse.ts
+++ b/src/websocket/createWSResponse.ts
@@ -229,7 +229,7 @@ export const createInteractionSuccessResponse = (payload: InteractionSuccessPayl
  * ------------------------------------------------------------------------- */
 
 /**
- * Create SEND_MESSAGE response object
+ * Create SEND_MESSAGE response object.
  * @param {string} username caller username
  * @param {string} message message to send to all users
  */


### PR DESCRIPTION
- [x] Fix bug in onPlayedTileInteraction lambda function

**Bug**: if a user send `PLAYED_TILE_INTERACTION` with `meldType = CONSECUTIVE` before `TRIPLET`, the backend will take **both** `CONSECUTIVE and TRIPLET`.
**Expected behavior**: `only TRIPLET or QUAD` will be taken if there is any; if there is **no** `TRIPLET or QUAD`, `CONSECUTIVE` will be taken from the **next player** to the player who played the tile